### PR TITLE
ANT-160: Fixed rmmst issue before 4am

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = remindmail
-version = 2024.04.29.2
+version = 2024.05.09.1
 author = Tyler Woodfin
 author_email = feedback-remindmail@tyler.cloud
 description = Easily schedule reminders to be emailed

--- a/src/remind/reminder.py
+++ b/src/remind/reminder.py
@@ -75,7 +75,7 @@ class Reminder:
         path_remind_file: The path from ReminderManager in which to access remind.md
     """
     def __init__(self,
-                 key: ReminderKeyType,
+                 key,
                  value: Optional[str],
                  frequency: Optional[int],
                  offset: int,
@@ -85,7 +85,7 @@ class Reminder:
                  cabinet: Cabinet,
                  mail: Mail,
                  path_remind_file: str | None):
-        self.key: ReminderKeyType = key
+        self.key = key
         self.value: Optional[str] = value
         self.frequency: int = frequency or 0
         self.offset: int = offset

--- a/src/remind/reminder_manager.py
+++ b/src/remind/reminder_manager.py
@@ -8,7 +8,7 @@ import subprocess
 import sys
 import glob
 import readline
-from datetime import date, timedelta
+from datetime import date, timedelta, datetime
 from typing import List, Optional
 from rich.console import Console
 from remind.reminder import ReminderKeyType
@@ -136,7 +136,6 @@ class ReminderManager:
 
                     match = re.match(pattern_any_reminder, stripped_line)
                     if match:
-                        reminder_key: ReminderKeyType
                         details, reminder_modifiers, title = match.groups()
                         details = details.lower()
 
@@ -307,15 +306,20 @@ class ReminderManager:
         """
         Displays reminders scheduled for the upcoming <limit> days.
 
-        This method calculates the dates for the next <limit> days, starting from tomorrow,
-        and checks each day for scheduled reminders. For each day, it prints the date
+        This method calculates the dates for the next <limit> days, starting from tomorrow
+        (today if between midnight and 4am),
+        and it checks each day for scheduled reminders. For each day, it prints the date
         and any corresponding reminders. If there are no reminders for a specific day,
         it indicates so. Reminders with specific modifiers change the display style
         to highlight their importance or category.
         """
 
+        current_time = datetime.now().time()
+        start_day_offset = 0 if current_time.hour < 4 else 1
+
         # Prepare the next 7 days
-        dates = [date.today() + timedelta(days=i) for i in range(1, limit)]
+        dates = [date.today() + timedelta(days=i) for i in range(
+            start_day_offset, limit)]
 
         # Parse reminders file if necessary
         if not self.parsed_reminders:


### PR DESCRIPTION
- Removed type checking for `key` to avoid linting issues. This is implicitly checked appropriately.