### PR TITLE
tjw-84: Fixed recurring weekday reminders breaking

### DIFF
--- a/src/remind/query_manager.py
+++ b/src/remind/query_manager.py
@@ -187,6 +187,7 @@ class QueryManager:
                 key = ReminderKeyType.LATER
                 delete = False
         else:
+            delete = False
             # every n days
             if match := regex_patterns['every_n_days'].match(input_str):
                 key = ReminderKeyType.DAY

--- a/src/remind/reminder.py
+++ b/src/remind/reminder.py
@@ -359,6 +359,8 @@ class Reminder:
             ReminderKeyType.FRIDAY, ReminderKeyType.SATURDAY
         }:
             reminder_dict["day"] = self.key.db_value
+            reminder_dict["every"] = self.frequency or 1
+            del reminder_dict["date"]
         elif self.key == ReminderKeyType.WEEK:
             reminder_dict["every"] = self.frequency
             reminder_dict["unit"] = "weeks"

--- a/src/remind/reminder_manager.py
+++ b/src/remind/reminder_manager.py
@@ -141,28 +141,6 @@ class ReminderManager:
 
         return reminders
 
-    def write_reminder(self, reminder: reminder.Reminder) -> None:
-        """
-        Writes a reminder to the YAML file.
-        
-        Args:
-            reminder (Reminder): The reminder to write
-        """
-        # Read existing reminders
-        if not self.remind_path_file:
-            raise ValueError("remind_path_file is not set. Set with `cabinet -p remindmail path file <path>`")
-
-        reminder_dicts = YAMLManager.parse_yaml_file(self.remind_path_file)
-        
-        # Convert new reminder to dict
-        new_reminder_dict = YAMLManager.reminder_to_dict(reminder)
-        
-        # Add new reminder
-        reminder_dicts.append(new_reminder_dict)
-        
-        # Write back to file
-        YAMLManager.write_yaml_file(self.remind_path_file, reminder_dicts)
-
     @error_handler.ErrorHandler.exception_handler
     def generate(self, is_dry_run: bool, tags: Optional[List[str]] = None) -> None:
         """


### PR DESCRIPTION
- Set to not delete by default ("every" implies we don't want this)
- Removed unused function
- Fixed error where recurring weekday reminders (i.e. "every saturday") would write a `day` and `date` to the YML, which breaks the interpreter