### PR TITLE
tjw-208: Fix day-of-month reminder validation

### DIFF
--- a/src/remind/reminder.py
+++ b/src/remind/reminder.py
@@ -251,7 +251,10 @@ class Reminder:
                 raise ValueError(
                     "Day of month reminders require a non-empty integer value."
                 )
-            return target_date.day == self.value
+            day_of_month = int(str(self.value))
+            if day_of_month < 1 or day_of_month > 31:
+                raise ValueError("Day of month reminders require a value from 1 to 31.")
+            return target_date.day == day_of_month
 
         elif self.key in [
             ReminderKeyType.MONDAY,
@@ -427,12 +430,17 @@ class Reminder:
                 str(self.value), "%Y-%m-%d"
             ).date()
         elif self.key == ReminderKeyType.DAY_OF_MONTH:
-            if not self.value or not self.error_handler.is_valid_date(str(self.value)):
+            if not self.value or not str(self.value).isdigit():
                 raise ValueError(
                     "Reminder day of month cannot be empty and must be an "
                     "integer for day of month reminders."
                 )
-            reminder_dict["dom"] = self.value
+            day_of_month = int(str(self.value))
+            if day_of_month < 1 or day_of_month > 31:
+                raise ValueError(
+                    "Reminder day of month must be between 1 and 31."
+                )
+            reminder_dict["dom"] = day_of_month
         elif self.key in {
             ReminderKeyType.SUNDAY,
             ReminderKeyType.MONDAY,

--- a/test/test_day_of_month.py
+++ b/test/test_day_of_month.py
@@ -1,0 +1,66 @@
+import tempfile
+import unittest
+from datetime import date
+
+import yaml
+
+from remind.reminder import Reminder, ReminderKeyType
+
+
+class _FakeCabinet:
+    def log(self, *args, **kwargs):
+        return None
+
+    def get(self, *args, **kwargs):
+        return None
+
+    def logdb(self, *args, **kwargs):
+        return None
+
+
+class _FakeMail:
+    def send(self, *args, **kwargs):
+        return None
+
+
+class DayOfMonthReminderTests(unittest.TestCase):
+    def _build_reminder(self, path_remind_file: str, value: str) -> Reminder:
+        return Reminder(
+            key=ReminderKeyType.DAY_OF_MONTH,
+            title="Check statements",
+            value=value,
+            frequency=None,
+            starts_on=None,
+            offset=0,
+            delete=False,
+            command="",
+            notes="",
+            index=0,
+            cabinet=_FakeCabinet(),
+            mail=_FakeMail(),
+            path_remind_file=path_remind_file,
+        )
+
+    def test_day_of_month_matches_when_value_is_string(self):
+        reminder = self._build_reminder("/tmp/remindmail.yml", "15")
+
+        self.assertTrue(reminder.get_should_send_today(target_date=date(2026, 4, 15)))
+        self.assertFalse(reminder.get_should_send_today(target_date=date(2026, 4, 16)))
+
+    def test_write_to_file_persists_day_of_month_as_integer(self):
+        with tempfile.NamedTemporaryFile(suffix=".yml") as remind_file:
+            reminder = self._build_reminder(remind_file.name, "15")
+
+            reminder.write_to_file()
+
+            remind_file.seek(0)
+            data = yaml.safe_load(remind_file.read()) or {}
+
+        self.assertEqual(
+            data,
+            {"reminders": [{"name": "Check statements", "dom": 15}]},
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Treat day-of-month reminder values as integers so reminders can be saved and evaluated correctly. This prevents monthly reminders from failing validation in the manual reminder flow and adds focused regression coverage.

Made-with: Cursor