### PR TITLE
TJW-269: Add annual every-month-day reminder support

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,46 @@
+# Agent / LLM guide for remindmail
+
+Use this when implementing Taiga tickets or other changes in `~/git/remindmail`.
+
+## Branching workflow
+
+Always work from a **release branch**, not directly from `main`/`master`:
+
+1. Checkout and pull latest `main` (this repo uses `main` as the default branch):
+
+   ```bash
+   cd ~/git/remindmail
+   git checkout main
+   git pull origin main
+   ```
+
+2. Cut a **release branch** from `main` using the next version (semver patch/minor as appropriate):
+
+   ```bash
+   git checkout -b release/X.Y.Z
+   # bump `version` in setup.cfg to `1!X.Y.Z` and commit:
+   #   X.Y.Z: Bumped version
+   ```
+
+3. Create a **ticket branch** from that release branch (ticket ref lowercase, e.g. `tjw-269`):
+
+   ```bash
+   git checkout -b tjw-269
+   ```
+
+4. Implement on the ticket branch. Commit messages: `tjw-269: short summary` (or `TJW-269:`).
+
+5. Open a PR **from the ticket branch → the release branch** (not into `main`).
+
+6. After review/merge into the release branch, a separate PR merges `release/X.Y.Z` → `main`.
+
+## Implementation notes
+
+- Prefer the smallest correct diff; match existing style in `src/remind/`.
+- Add or extend unit tests under `test/` for parser and send-today logic.
+- Natural-language `when` parsing lives in `query_manager.QueryManager.interpret_reminder_date`.
+- YAML shape and annual dates (`MM-DD`) are documented in `README.md`.
+
+## Before finishing
+
+Double-check for stray issues elsewhere in the app. If you find unrelated bugs, **ask before fixing** them (do not scope-creep).

--- a/README.md
+++ b/README.md
@@ -140,6 +140,7 @@ remind -m cabinet --config
 - `remind --title 'reminder title' --when 'friday'`: Schedule a new reminder programatically
 - `remind --title 'reminder title' --when friday --save`: Schedule a new reminder programatically, saves without confirmation
 - `remind --title 'reminder title' --when 'every 2 Mondays'`: Schedule a new reminder programatically
+- `remind --title 'Donate to Wikipedia' --when 'every december 1'`: Schedule an annual reminder (stored as `MM-DD`)
 - `remind --title 'reminder title' --when 'now'`: Sends an email immediately
 - `remind -h` (or `--help`): Displays usage information.
 - `remind -g` (or `--generate`): Generates reminders scheduled for today.
@@ -210,7 +211,8 @@ remind -m cabinet --config
 
 #### `date`
 - **Type:** `string` (`YYYY-MM-DD` or `MM-DD`)
-- **Description:** A specific one-time or annual date for the reminder.
+- **Description:** A specific one-time (`YYYY-MM-DD`) or annual (`MM-DD`) date for the reminder.
+- **CLI:** `every december 1` (and month-name variants) creates an annual `MM-DD` reminder.
 
 #### `later`
 - **Type:** `bool`
@@ -289,6 +291,8 @@ reminders:
     date: 2025-03-31
     delete: true
     notes: This will be <u>VERY</u> useful! <b>WOW</b>
+  - name: Donate to Wikipedia
+    date: 12-01
   - name: Laundry and Sheets
     every: 6
     offset: 5

--- a/src/remind/error_handler.py
+++ b/src/remind/error_handler.py
@@ -46,10 +46,14 @@ class ErrorHandler:
 
     def is_valid_date(self, date_str: str) -> bool:
         """
-        Checks if a date string is valid
+        Checks if a date string is valid.
+
+        Accepts one-time ``YYYY-MM-DD`` and annual ``MM-DD`` formats.
         """
-        try:
-            datetime.strptime(date_str, "%Y-%m-%d")
-            return True
-        except ValueError:
-            return False
+        for fmt in ("%Y-%m-%d", "%m-%d"):
+            try:
+                datetime.strptime(date_str, fmt)
+                return True
+            except ValueError:
+                continue
+        return False

--- a/src/remind/query_manager.py
+++ b/src/remind/query_manager.py
@@ -144,6 +144,14 @@ class QueryManager:
                 r"|wed|thursday|thu|friday|fri|saturday|sat|sunday|sun)s?",
                 re.IGNORECASE,
             ),
+            # e.g. "every december 1", "every Dec 1st"
+            "every_month_day": re.compile(
+                r"(?i)^every\s+("
+                r"january|february|march|april|may|june|july|august|"
+                r"september|october|november|december|"
+                r"jan|feb|mar|apr|jun|jul|aug|sep|sept|oct|nov|dec"
+                r")\.?\s+(\d{1,2})(?:st|nd|rd|th)?$"
+            ),
         }
 
         # common replacements
@@ -259,8 +267,28 @@ class QueryManager:
                 delete = False
         else:
             delete = False
+            # every <month> <day> (annual, e.g. "every december 1")
+            if match := regex_patterns["every_month_day"].match(input_str):
+                month_word = match.group(1).lower().rstrip(".")
+                month_num = _MONTH_NAME_TO_NUM.get(month_word)
+                if month_num is None:
+                    self.cabinet.log(
+                        f"Unrecognized month in date: {month_word!r}",
+                        level="warn",
+                        is_quiet=True,
+                    )
+                    raise ValueError("Sorry, I didn't understand that.")
+                day = int(match.group(2))
+                try:
+                    # Validate month/day combo (use leap year so Feb 29 is allowed)
+                    datetime(2024, month_num, day)
+                except ValueError as exc:
+                    raise ValueError("Sorry, I didn't understand that.") from exc
+                key = ReminderKeyType.DATE
+                value = f"{month_num:02d}-{day:02d}"
+
             # every n days
-            if match := regex_patterns["every_n_days"].match(input_str):
+            elif match := regex_patterns["every_n_days"].match(input_str):
                 key = ReminderKeyType.DAY
                 frequency = int(match.group(1) or 1)
 

--- a/src/remind/reminder.py
+++ b/src/remind/reminder.py
@@ -106,7 +106,7 @@ class Reminder:
         key (ReminderKeyType).
         - This is the type of reminder, such as on a certain day, date, or month.
         value (Optional[str]): Specific value, depending on the `key`.
-            - if key is "date", expect YYYY-MM-DD str
+            - if key is "date", expect YYYY-MM-DD (one-time) or MM-DD (annual) str
             - if key is "dow", expect "sun" - "sat"
             - if key is "dom", expect 1-30 as string
             - otherwise, value is ignored
@@ -428,9 +428,12 @@ class Reminder:
                 raise ValueError(
                     "Reminder date cannot be empty and must be a date for date reminders."
                 )
-            reminder_dict["date"] = datetime.strptime(
-                str(self.value), "%Y-%m-%d"
-            ).date()
+            date_str = str(self.value)
+            # Annual MM-DD stays a string; one-time YYYY-MM-DD becomes a date
+            if len(date_str.split("-")) == 2:
+                reminder_dict["date"] = date_str
+            else:
+                reminder_dict["date"] = datetime.strptime(date_str, "%Y-%m-%d").date()
         elif self.key == ReminderKeyType.DAY_OF_MONTH:
             if not self.value or not str(self.value).isdigit():
                 raise ValueError(

--- a/src/remind/reminder_confirmation.py
+++ b/src/remind/reminder_confirmation.py
@@ -66,11 +66,12 @@ class ReminderConfirmation:
         email_text = self.email_text_area.text.strip()
         self.reminder.email = email_text if email_text else None
 
-        # warn if reminder is in the past
+        # warn if one-time reminder is in the past (skip annual MM-DD)
         if (
             self.reminder.key == ReminderKeyType.DATE
             and self.reminder.value
-            and datetime.datetime.strptime(self.reminder.value, "%Y-%m-%d")
+            and len(str(self.reminder.value).split("-")) == 3
+            and datetime.datetime.strptime(str(self.reminder.value), "%Y-%m-%d")
             < datetime.datetime.now()
         ):
             print_formatted_text(
@@ -501,13 +502,24 @@ class ReminderConfirmation:
                     new_index = (index + 1) % 7 if increment else (index - 1 + 7) % 7
                     new_value = days_of_week[new_index]
                 elif self.reminder.key == ReminderKeyType.DATE:
-                    # Handle date increment/decrement
-                    current_date = datetime.datetime.strptime(
-                        current_value, "%Y-%m-%d"
-                    ).date()
+                    # Handle date increment/decrement (YYYY-MM-DD or annual MM-DD)
+                    date_str = str(current_value)
+                    is_annual = len(date_str.split("-")) == 2
+                    if is_annual:
+                        current_date = datetime.datetime.strptime(
+                            date_str, "%m-%d"
+                        ).replace(year=datetime.datetime.now().year).date()
+                    else:
+                        current_date = datetime.datetime.strptime(
+                            date_str, "%Y-%m-%d"
+                        ).date()
                     delta = datetime.timedelta(days=1 if increment else -1)
-                    new_value = current_date + delta
-                    new_value = new_value.strftime("%Y-%m-%d")
+                    new_date = current_date + delta
+                    new_value = (
+                        new_date.strftime("%m-%d")
+                        if is_annual
+                        else new_date.strftime("%Y-%m-%d")
+                    )
                 else:
                     # Handle numeric increments/decrements
                     current_value = int(current_value)
@@ -718,12 +730,17 @@ class ReminderConfirmation:
         value_text = f"{self.value_text_area.text}"
         if rtype == ReminderKeyType.DATE.label:
             try:
-                # attempt to parse dow from the text
-                date = datetime.datetime.strptime(value_text, "%Y-%m-%d")
+                # attempt to parse dow from the text (YYYY-MM-DD or annual MM-DD)
+                try:
+                    date = datetime.datetime.strptime(value_text, "%Y-%m-%d")
+                except ValueError:
+                    date = datetime.datetime.strptime(value_text, "%m-%d").replace(
+                        year=datetime.datetime.now().year
+                    )
                 value_text = date.strftime("%A")
             except ValueError:
                 # Set default text if parsing fails
-                value_text = "Enter a Date (YYYY-MM-DD)"
+                value_text = "Enter a Date (YYYY-MM-DD or MM-DD)"
 
         # handle different verbiage based on frequency
         if self.frequency_text_area.text == "0":
@@ -735,7 +752,9 @@ class ReminderConfirmation:
             self.toolbar_text = "The title for your reminder"
         elif self.application.layout.has_focus(self.type_text_area):
             if self.type_text_area.text == ReminderKeyType.DATE.label:
-                self.toolbar_text = "Send on a specific date (YYYY-MM-DD)"
+                self.toolbar_text = (
+                    "Send on a specific date (YYYY-MM-DD or annual MM-DD)"
+                )
             elif self.reminder.key == ReminderKeyType.LATER:
                 self.toolbar_text = "Save for Later"
             elif self.reminder.key == ReminderKeyType.NOW:

--- a/test/test_every_month_day.py
+++ b/test/test_every_month_day.py
@@ -1,0 +1,112 @@
+"""Tests for annual 'every <month> <day>' reminders (TJW-269)."""
+
+import tempfile
+import unittest
+from datetime import date
+from unittest.mock import MagicMock
+
+import yaml
+
+from remind.query_manager import QueryManager
+from remind.reminder import Reminder, ReminderKeyType
+
+
+class _FakeCabinet:
+    def log(self, *args, **kwargs):
+        return None
+
+    def get(self, *args, **kwargs):
+        return None
+
+
+class _FakeMail:
+    def send(self, *args, **kwargs):
+        return None
+
+
+class EveryMonthDayTests(unittest.TestCase):
+    def setUp(self):
+        manager = MagicMock()
+        manager.cabinet = _FakeCabinet()
+        manager.mail = _FakeMail()
+        manager.remind_path_file = "/tmp/remindmail.yml"
+        self.query = QueryManager(manager)
+
+    def test_parse_every_december_1(self):
+        reminder = self.query.interpret_reminder_date("every december 1")
+
+        self.assertEqual(reminder.key, ReminderKeyType.DATE)
+        self.assertEqual(reminder.value, "12-01")
+        self.assertFalse(reminder.delete)
+
+    def test_parse_every_dec_1st(self):
+        reminder = self.query.interpret_reminder_date("every Dec 1st")
+
+        self.assertEqual(reminder.key, ReminderKeyType.DATE)
+        self.assertEqual(reminder.value, "12-01")
+        self.assertFalse(reminder.delete)
+
+    def test_parse_every_july_4(self):
+        reminder = self.query.interpret_reminder_date("every July 4")
+
+        self.assertEqual(reminder.key, ReminderKeyType.DATE)
+        self.assertEqual(reminder.value, "07-04")
+        self.assertFalse(reminder.delete)
+
+    def test_parse_invalid_month_day_raises(self):
+        with self.assertRaises(ValueError):
+            self.query.interpret_reminder_date("every february 30")
+
+    def test_annual_date_matches_each_year(self):
+        reminder = Reminder(
+            key=ReminderKeyType.DATE,
+            title="Donate to Wikipedia",
+            value="12-01",
+            frequency=None,
+            starts_on=None,
+            offset=0,
+            delete=False,
+            command="",
+            notes="",
+            index=0,
+            cabinet=_FakeCabinet(),
+            mail=_FakeMail(),
+            path_remind_file="/tmp/remindmail.yml",
+        )
+
+        self.assertTrue(reminder.get_should_send_today(target_date=date(2026, 12, 1)))
+        self.assertTrue(reminder.get_should_send_today(target_date=date(2027, 12, 1)))
+        self.assertFalse(reminder.get_should_send_today(target_date=date(2026, 12, 2)))
+        self.assertFalse(reminder.get_should_send_today(target_date=date(2026, 11, 30)))
+
+    def test_write_to_file_persists_annual_mm_dd(self):
+        with tempfile.NamedTemporaryFile(suffix=".yml") as remind_file:
+            reminder = Reminder(
+                key=ReminderKeyType.DATE,
+                title="Donate to Wikipedia",
+                value="12-01",
+                frequency=None,
+                starts_on=None,
+                offset=0,
+                delete=False,
+                command="",
+                notes="",
+                index=0,
+                cabinet=_FakeCabinet(),
+                mail=_FakeMail(),
+                path_remind_file=remind_file.name,
+            )
+
+            reminder.write_to_file()
+
+            remind_file.seek(0)
+            data = yaml.safe_load(remind_file.read()) or {}
+
+        self.assertEqual(
+            data,
+            {"reminders": [{"name": "Donate to Wikipedia", "date": "12-01"}]},
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- Parse `every december 1` (and month-name / ordinal variants) as recurring annual `MM-DD` date reminders
- Persist and validate `MM-DD` dates correctly; update confirmation UI to handle annual dates
- Add `AGENTS.md` documenting the remindmail release-branch workflow for LLMs

## Test plan
- [ ] `PYTHONPATH=src python3 -m unittest test_every_month_day test_day_of_month` from `test/`
- [ ] `remind --title 'Donate to Wikipedia' --when 'every december 1' --save` writes `date: 12-01` with no delete
- [ ] `rmm every december 1, donate to wikipedia` no longer fails with "Sorry, I didn't understand that."
- [ ] One-time `december 1` still creates `YYYY-MM-DD` with delete
