### PR TITLE
TJW-302: Fix every-N-months mis-parsed as Monday

### DIFF
--- a/src/remind/query_manager.py
+++ b/src/remind/query_manager.py
@@ -42,6 +42,19 @@ _MONTH_NAME_TO_NUM: dict[str, int] = {
 }
 
 
+def _match_weekday_token(text: str, weekday_tokens: dict) -> str | None:
+    """
+    Return the longest weekday token found as a whole word in ``text``.
+
+    Uses word boundaries so ``mon`` does not match inside ``months``.
+    Longer tokens are preferred (``monday`` before ``mon``).
+    """
+    for day in sorted(weekday_tokens.keys(), key=len, reverse=True):
+        if re.search(rf"\b{re.escape(day)}\b", text, flags=re.IGNORECASE):
+            return day.lower()
+    return None
+
+
 class QueryManager:
     """
     handles reminder requests
@@ -125,7 +138,7 @@ class QueryManager:
             "day_of_month": re.compile(
                 r"\b(?:the )?(\d{1,2})(st|nd|rd|th)?\b", re.IGNORECASE
             ),
-            "every_weeks": re.compile(r"every (\d+) weeks?", re.IGNORECASE),
+            "every_weeks": re.compile(r"^every (\d+) weeks?$", re.IGNORECASE),
             "specific_date": re.compile(
                 r"(?i)\b("
                 r"january|february|march|april|may|june|july|august|"
@@ -136,12 +149,12 @@ class QueryManager:
             "mm_dd": re.compile(r"(\d{1,2})/(\d{1,2})"),
             "mm_dd_yyyy": re.compile(r"(\d{1,2})/(\d{1,2})/(\d{4})"),
             "yyyy_mm_dd": re.compile(r"(\d{4})-(\d{1,2})-(\d{1,2})"),
-            "every_n_days": re.compile(r"every (\d+ )?day?s?", re.IGNORECASE),
-            "every_n_weeks": re.compile(r"every (\d+ )?week?s?", re.IGNORECASE),
-            "every_n_months": re.compile(r"every (\d+ )?month?s?", re.IGNORECASE),
+            "every_n_days": re.compile(r"^every (\d+ )?days?$", re.IGNORECASE),
+            "every_n_weeks": re.compile(r"^every (\d+ )?weeks?$", re.IGNORECASE),
+            "every_n_months": re.compile(r"^every (\d+ )?months?$", re.IGNORECASE),
             "every_n_dows": re.compile(
-                r"every (\d+) (monday|mon|tuesday|tue|wednesday"
-                r"|wed|thursday|thu|friday|fri|saturday|sat|sunday|sun)s?",
+                r"^every (\d+) (monday|mon|tuesday|tue|wednesday"
+                r"|wed|thursday|thu|friday|fri|saturday|sat|sunday|sun)s?$",
                 re.IGNORECASE,
             ),
         }
@@ -230,17 +243,13 @@ class QueryManager:
                     raise ValueError("Sorry, I didn't understand that.") from exc
                 key, value = set_date_key_value(date_formatted, value, key)
 
-            # specific weekday
-            elif any(day in input_str.lower() for day in weekdays):
-                day_str = input_str.lower()
-                for day, rel_day in weekdays.items():
-                    if day in day_str:
-                        next_weekday = start_date + relativedelta(
-                            days=1, weekday=rel_day
-                        )
-                        key = ReminderKeyType.DATE
-                        value = next_weekday.strftime("%Y-%m-%d")
-                        break
+            # specific weekday (word-boundary match; avoid "mon" inside "months")
+            elif weekday_token := _match_weekday_token(input_str, weekdays):
+                next_weekday = start_date + relativedelta(
+                    days=1, weekday=weekdays[weekday_token]
+                )
+                key = ReminderKeyType.DATE
+                value = next_weekday.strftime("%Y-%m-%d")
 
             # tomorrow
             elif input_str == "tomorrow":
@@ -259,21 +268,6 @@ class QueryManager:
                 delete = False
         else:
             delete = False
-            # every n days
-            if match := regex_patterns["every_n_days"].match(input_str):
-                key = ReminderKeyType.DAY
-                frequency = int(match.group(1) or 1)
-
-            # every n weeks
-            elif match := regex_patterns["every_n_weeks"].match(input_str):
-                key = ReminderKeyType.WEEK
-                frequency = int(match.group(1) or 1)
-
-            # every n months
-            elif match := regex_patterns["every_n_months"].match(input_str):
-                key = ReminderKeyType.MONTH
-                frequency = int(match.group(1) or 1)
-
             # Helper: Map full and abbreviated weekday names to ReminderKeyType
             weekday_to_keytype = {
                 "monday": ReminderKeyType.MONDAY,
@@ -292,28 +286,37 @@ class QueryManager:
                 "sun": ReminderKeyType.SUNDAY,
             }
 
+            # every n days
+            if match := regex_patterns["every_n_days"].match(input_str):
+                key = ReminderKeyType.DAY
+                frequency = int(match.group(1) or 1)
+
+            # every n weeks
+            elif match := regex_patterns["every_n_weeks"].match(input_str):
+                key = ReminderKeyType.WEEK
+                frequency = int(match.group(1) or 1)
+
+            # every n months
+            elif match := regex_patterns["every_n_months"].match(input_str):
+                key = ReminderKeyType.MONTH
+                frequency = int(match.group(1) or 1)
+
             # every n {dow}s (e.g., 'every 3 mondays')
-            if match := regex_patterns["every_n_dows"].match(input_str):
+            elif match := regex_patterns["every_n_dows"].match(input_str):
                 dow = match.group(2).lower()
                 if dow in weekdays:
-                    key = weekday_to_keytype[
-                        dow
-                    ]  # Get the corresponding ReminderKeyType
+                    key = weekday_to_keytype[dow]
                     value = dow
                     frequency = int(match.group(1))
 
-            # every {dow} (e.g., 'every friday')
-            elif any(day in input_str.lower() for day in weekdays):
-                day_str = input_str.lower()
-                for day, rel_day in weekdays.items():
-                    if day in day_str:
-                        next_weekday = start_date + relativedelta(weekday=rel_day(0))
-                        key = weekday_to_keytype[day]  # Use the same mapping
-                        value = day
-                        frequency = 1
-                        break
+            # every {dow} (e.g., 'every friday') — word-boundary match
+            elif weekday_token := _match_weekday_token(input_str, weekdays):
+                key = weekday_to_keytype[weekday_token]
+                value = weekday_token
+                frequency = 1
 
-            # every n weeks
+            # every n weeks (explicit "every N weeks" already handled above;
+            # keep for "every 2 week" singular edge via every_weeks pattern)
             elif match := regex_patterns["every_weeks"].match(input_str):
                 key = ReminderKeyType.WEEK
                 frequency = int(match.group(1))

--- a/test/test_when_edge_cases.py
+++ b/test/test_when_edge_cases.py
@@ -1,0 +1,175 @@
+"""Edge-case coverage for interpret_reminder_date (TJW-302)."""
+
+import unittest
+from unittest.mock import MagicMock
+
+from remind.query_manager import QueryManager, _match_weekday_token
+from remind.reminder import ReminderKeyType
+
+
+class _FakeCabinet:
+    def log(self, *args, **kwargs):
+        return None
+
+    def get(self, *args, **kwargs):
+        return None
+
+
+class _FakeMail:
+    def send(self, *args, **kwargs):
+        return None
+
+
+class ReminderWhenEdgeCaseTests(unittest.TestCase):
+    def setUp(self):
+        manager = MagicMock()
+        manager.cabinet = _FakeCabinet()
+        manager.mail = _FakeMail()
+        manager.remind_path_file = "/tmp/remindmail.yml"
+        self.query = QueryManager(manager)
+
+    def _parse(self, when: str):
+        return self.query.interpret_reminder_date(when)
+
+    # --- the months / Monday regression ---
+
+    def test_every_month_is_monthly_not_monday(self):
+        reminder = self._parse("every month")
+        self.assertEqual(reminder.key, ReminderKeyType.MONTH)
+        self.assertEqual(reminder.frequency, 1)
+        self.assertFalse(reminder.delete)
+
+    def test_every_3_months_is_monthly_not_monday(self):
+        reminder = self._parse("every 3 months")
+        self.assertEqual(reminder.key, ReminderKeyType.MONTH)
+        self.assertEqual(reminder.frequency, 3)
+
+    def test_every_2_months(self):
+        reminder = self._parse("every 2 months")
+        self.assertEqual(reminder.key, ReminderKeyType.MONTH)
+        self.assertEqual(reminder.frequency, 2)
+
+    def test_mon_not_matched_inside_months(self):
+        self.assertIsNone(
+            _match_weekday_token("every 3 months", {"mon": object(), "monday": object()})
+        )
+
+    # --- interval reminders ---
+
+    def test_every_day(self):
+        reminder = self._parse("every day")
+        self.assertEqual(reminder.key, ReminderKeyType.DAY)
+        self.assertEqual(reminder.frequency, 1)
+
+    def test_every_2_days(self):
+        reminder = self._parse("every 2 days")
+        self.assertEqual(reminder.key, ReminderKeyType.DAY)
+        self.assertEqual(reminder.frequency, 2)
+
+    def test_every_week_becomes_sunday(self):
+        reminder = self._parse("every week")
+        self.assertEqual(reminder.key, ReminderKeyType.SUNDAY)
+        self.assertEqual(reminder.frequency, 1)
+
+    def test_every_2_weeks(self):
+        reminder = self._parse("every 2 weeks")
+        self.assertEqual(reminder.key, ReminderKeyType.WEEK)
+        self.assertEqual(reminder.frequency, 2)
+
+    # --- weekday reminders ---
+
+    def test_every_monday(self):
+        reminder = self._parse("every monday")
+        self.assertEqual(reminder.key, ReminderKeyType.MONDAY)
+        self.assertEqual(reminder.frequency, 1)
+
+    def test_every_mon_abbrev(self):
+        reminder = self._parse("every mon")
+        self.assertEqual(reminder.key, ReminderKeyType.MONDAY)
+
+    def test_every_3_mondays(self):
+        reminder = self._parse("every 3 mondays")
+        self.assertEqual(reminder.key, ReminderKeyType.MONDAY)
+        self.assertEqual(reminder.frequency, 3)
+
+    def test_every_friday(self):
+        reminder = self._parse("every friday")
+        self.assertEqual(reminder.key, ReminderKeyType.FRIDAY)
+
+    def test_one_shot_friday_is_date(self):
+        reminder = self._parse("friday")
+        self.assertEqual(reminder.key, ReminderKeyType.DATE)
+        self.assertTrue(reminder.delete)
+        self.assertRegex(str(reminder.value), r"^\d{4}-\d{2}-\d{2}$")
+
+    # --- one-shot / special ---
+
+    def test_tomorrow(self):
+        reminder = self._parse("tomorrow")
+        self.assertEqual(reminder.key, ReminderKeyType.DATE)
+        self.assertTrue(reminder.delete)
+
+    def test_now(self):
+        reminder = self._parse("now")
+        self.assertEqual(reminder.key, ReminderKeyType.NOW)
+
+    def test_later(self):
+        reminder = self._parse("later")
+        self.assertEqual(reminder.key, ReminderKeyType.LATER)
+        self.assertFalse(reminder.delete)
+
+    def test_day_of_month(self):
+        reminder = self._parse("15")
+        self.assertEqual(reminder.key, ReminderKeyType.DAY_OF_MONTH)
+        self.assertEqual(reminder.value, "15")
+
+    def test_the_15th(self):
+        reminder = self._parse("the 15th")
+        self.assertEqual(reminder.key, ReminderKeyType.DAY_OF_MONTH)
+        self.assertEqual(reminder.value, "15")
+
+    def test_specific_month_day(self):
+        reminder = self._parse("december 1")
+        self.assertEqual(reminder.key, ReminderKeyType.DATE)
+        self.assertRegex(str(reminder.value), r"^\d{4}-12-01$")
+        self.assertTrue(reminder.delete)
+
+    def test_mm_dd(self):
+        reminder = self._parse("12/25")
+        self.assertEqual(reminder.key, ReminderKeyType.DATE)
+        self.assertRegex(str(reminder.value), r"^\d{4}-12-25$")
+
+    def test_yyyy_mm_dd_future(self):
+        reminder = self._parse("2099-07-04")
+        self.assertEqual(reminder.key, ReminderKeyType.DATE)
+        self.assertEqual(reminder.value, "2099-07-04")
+
+    def test_yyyy_mm_dd_past_rolls_to_next_year(self):
+        """Past calendar dates without an explicit future year roll forward one year."""
+        reminder = self._parse("2020-01-01")
+        self.assertEqual(reminder.key, ReminderKeyType.DATE)
+        # set_date_key_value advances past dates by one year from the proposed date
+        self.assertEqual(reminder.value, "2021-01-01")
+
+    def test_relative_in_3_days(self):
+        reminder = self._parse("in 3 days")
+        self.assertEqual(reminder.key, ReminderKeyType.DATE)
+        self.assertRegex(str(reminder.value), r"^\d{4}-\d{2}-\d{2}$")
+
+    def test_relative_in_2_weeks(self):
+        reminder = self._parse("in 2 weeks")
+        self.assertEqual(reminder.key, ReminderKeyType.DATE)
+
+    def test_relative_in_2_months(self):
+        """Relative 'in 2 months' must stay a one-shot date, not a weekday."""
+        reminder = self._parse("in 2 months")
+        self.assertEqual(reminder.key, ReminderKeyType.DATE)
+        self.assertTrue(reminder.delete)
+
+    def test_unknown_raises(self):
+        with self.assertRaises(ValueError):
+            self._parse("blargle")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- Fix every month / every 3 months mis-parsed as Monday
- Word-boundary weekday matching + elif chaining
- Edge-case tests for reminder when types

## Test plan
- [ ] PYTHONPATH=../src python3 -m unittest test_when_edge_cases
- [ ] every 3 months saves as unit months
- [ ] every monday still works

## Merge note
Prefer merging before #110 (TJW-269).