### PR TITLE
TJW-304: Fix annual February 29 save and send behavior

### DIFF
--- a/src/remind/error_handler.py
+++ b/src/remind/error_handler.py
@@ -44,16 +44,34 @@ class ErrorHandler:
 
         return wrapper
 
+    @staticmethod
+    def parse_mm_dd(date_str: str) -> tuple[int, int] | None:
+        """
+        Parse an annual ``MM-DD`` string into ``(month, day)``.
+
+        Uses a leap year for validation so ``02-29`` is accepted.
+        Returns ``None`` if the string is not a valid month/day.
+        """
+        parts = str(date_str).split("-")
+        if len(parts) != 2:
+            return None
+        try:
+            month, day = int(parts[0]), int(parts[1])
+            # Leap year so February 29 is valid
+            datetime(2024, month, day)
+            return month, day
+        except ValueError:
+            return None
+
     def is_valid_date(self, date_str: str) -> bool:
         """
         Checks if a date string is valid.
 
-        Accepts one-time ``YYYY-MM-DD`` and annual ``MM-DD`` formats.
+        Accepts one-time ``YYYY-MM-DD`` and annual ``MM-DD`` formats
+        (including ``02-29``).
         """
-        for fmt in ("%Y-%m-%d", "%m-%d"):
-            try:
-                datetime.strptime(date_str, fmt)
-                return True
-            except ValueError:
-                continue
-        return False
+        try:
+            datetime.strptime(date_str, "%Y-%m-%d")
+            return True
+        except ValueError:
+            return self.parse_mm_dd(date_str) is not None

--- a/src/remind/reminder.py
+++ b/src/remind/reminder.py
@@ -218,12 +218,25 @@ class Reminder:
                 return False
 
             try:
-                if len(date_parts) == 2:  # MM-DD format
-                    month, day = map(int, date_parts)
+                if len(date_parts) == 2:  # MM-DD format (annual)
+                    month, stored_day = map(int, date_parts)
+
+                    def _annual_day_for_year(year: int) -> int:
+                        # Feb 29 in non-leap years fires on Feb 28
+                        if (
+                            month == 2
+                            and stored_day == 29
+                            and not calendar.isleap(year)
+                        ):
+                            return 28
+                        return stored_day
+
                     year = target_date.year
+                    day = _annual_day_for_year(year)
                     # If the date has already passed this year, use next year
                     if (month, day) < (target_date.month, target_date.day):
                         year += 1
+                        day = _annual_day_for_year(year)
                 else:  # YYYY-MM-DD format
                     year, month, day = map(int, date_parts)
             except ValueError:

--- a/src/remind/reminder_confirmation.py
+++ b/src/remind/reminder_confirmation.py
@@ -14,6 +14,7 @@ from prompt_toolkit.widgets import TextArea, Box, Label
 from prompt_toolkit.layout.containers import WindowAlign, ConditionalContainer
 from prompt_toolkit.filters import has_focus, Condition
 from remind.reminder import Reminder, ReminderKeyType
+from remind.error_handler import ErrorHandler
 
 
 class ReminderConfirmation:
@@ -506,9 +507,12 @@ class ReminderConfirmation:
                     date_str = str(current_value)
                     is_annual = len(date_str.split("-")) == 2
                     if is_annual:
-                        current_date = datetime.datetime.strptime(
-                            date_str, "%m-%d"
-                        ).replace(year=datetime.datetime.now().year).date()
+                        parsed = ErrorHandler.parse_mm_dd(date_str)
+                        if parsed is None:
+                            return
+                        month, day = parsed
+                        # Use a leap year so Feb 29 can be represented
+                        current_date = datetime.date(2024, month, day)
                     else:
                         current_date = datetime.datetime.strptime(
                             date_str, "%Y-%m-%d"
@@ -734,9 +738,12 @@ class ReminderConfirmation:
                 try:
                     date = datetime.datetime.strptime(value_text, "%Y-%m-%d")
                 except ValueError:
-                    date = datetime.datetime.strptime(value_text, "%m-%d").replace(
-                        year=datetime.datetime.now().year
-                    )
+                    parsed = ErrorHandler.parse_mm_dd(value_text)
+                    if parsed is None:
+                        raise ValueError("invalid annual date")
+                    month, day = parsed
+                    # Leap year so Feb 29 can be formatted for weekday label
+                    date = datetime.datetime(2024, month, day)
                 value_text = date.strftime("%A")
             except ValueError:
                 # Set default text if parsing fails

--- a/test/test_feb29_annual.py
+++ b/test/test_feb29_annual.py
@@ -1,0 +1,112 @@
+"""Tests for annual February 29 handling (TJW-304)."""
+
+import tempfile
+import unittest
+from datetime import date
+
+import yaml
+
+from remind.error_handler import ErrorHandler
+from remind.query_manager import QueryManager
+from remind.reminder import Reminder, ReminderKeyType
+from unittest.mock import MagicMock
+
+
+class _FakeCabinet:
+    def log(self, *args, **kwargs):
+        return None
+
+    def get(self, *args, **kwargs):
+        return None
+
+
+class _FakeMail:
+    def send(self, *args, **kwargs):
+        return None
+
+
+class Feb29AnnualTests(unittest.TestCase):
+    def setUp(self):
+        manager = MagicMock()
+        manager.cabinet = _FakeCabinet()
+        manager.mail = _FakeMail()
+        manager.remind_path_file = "/tmp/remindmail.yml"
+        self.query = QueryManager(manager)
+
+    def test_is_valid_date_accepts_02_29(self):
+        self.assertTrue(ErrorHandler().is_valid_date("02-29"))
+        self.assertEqual(ErrorHandler.parse_mm_dd("02-29"), (2, 29))
+
+    def test_parse_every_february_29(self):
+        reminder = self.query.interpret_reminder_date("every february 29")
+        self.assertEqual(reminder.key, ReminderKeyType.DATE)
+        self.assertEqual(reminder.value, "02-29")
+        self.assertFalse(reminder.delete)
+
+    def test_write_to_file_persists_02_29(self):
+        with tempfile.NamedTemporaryFile(suffix=".yml") as remind_file:
+            reminder = Reminder(
+                key=ReminderKeyType.DATE,
+                title="Leap day",
+                value="02-29",
+                frequency=None,
+                starts_on=None,
+                offset=0,
+                delete=False,
+                command="",
+                notes="",
+                index=0,
+                cabinet=_FakeCabinet(),
+                mail=_FakeMail(),
+                path_remind_file=remind_file.name,
+            )
+            reminder.write_to_file()
+            remind_file.seek(0)
+            data = yaml.safe_load(remind_file.read()) or {}
+
+        self.assertEqual(
+            data,
+            {"reminders": [{"name": "Leap day", "date": "02-29"}]},
+        )
+
+    def test_sends_on_feb_29_in_leap_year(self):
+        reminder = Reminder(
+            key=ReminderKeyType.DATE,
+            title="Leap day",
+            value="02-29",
+            frequency=None,
+            starts_on=None,
+            offset=0,
+            delete=False,
+            command="",
+            notes="",
+            index=0,
+            cabinet=_FakeCabinet(),
+            mail=_FakeMail(),
+            path_remind_file="/tmp/remindmail.yml",
+        )
+        self.assertTrue(reminder.get_should_send_today(target_date=date(2024, 2, 29)))
+        self.assertFalse(reminder.get_should_send_today(target_date=date(2024, 2, 28)))
+
+    def test_sends_on_feb_28_in_non_leap_year(self):
+        reminder = Reminder(
+            key=ReminderKeyType.DATE,
+            title="Leap day",
+            value="02-29",
+            frequency=None,
+            starts_on=None,
+            offset=0,
+            delete=False,
+            command="",
+            notes="",
+            index=0,
+            cabinet=_FakeCabinet(),
+            mail=_FakeMail(),
+            path_remind_file="/tmp/remindmail.yml",
+        )
+        self.assertTrue(reminder.get_should_send_today(target_date=date(2025, 2, 28)))
+        self.assertFalse(reminder.get_should_send_today(target_date=date(2025, 3, 1)))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- Accept annual `02-29` in `is_valid_date` so `every february 29` can be saved
- Fix confirmation UI MM-DD parsing so leap day does not crash date +/- / toolbar
- Fire Feb 29 annuals on Feb 28 in non-leap years

## Test plan
- [ ] From `test/`: `PYTHONPATH=../src python3 -m unittest test_feb29_annual test_every_month_day test_when_edge_cases`
- [ ] `remind --title 'Leap' --when 'every february 29' --save` writes `date: 02-29`
- [ ] Confirmation UI: create annual Feb 29 and use left/right on the date field without crash
