### PR TITLE
TJW-318: Update Checker

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,7 @@ remind -m cabinet --config
   "remindmail": {
     "mongodb_enabled": true, # optional if using mongodb - default false
     "subject_prefix": "Reminder ", # optional - custom prefix for email subjects (default: "📌 ")
+    "update-checks": true, # optional - email once per new release during --generate (default: true)
     "path": {
         "file": "/path/to/remindmail.yml"
     }
@@ -115,6 +116,8 @@ remind -m cabinet --config
 - Gmail will _not_ work due to their security restrictions.
 
 - it's very bad practice to store your password in plaintext; take appropriate precautions.
+
+- When `update-checks` is `true` (the default), `remind --generate` checks PyPI for a newer RemindMail version. If one is available, you get a single email per release (subject like `🎉 RemindMail 4.0.0 Released`) with upgrade instructions. Set `"update-checks": false` to disable. RemindMail stores `last_notified_version` automatically so each version is only emailed once.
 
 ### MongoDB Configuration
 - MongoDB is used to log reminders when `mongodb_enabled` is set to `true`.
@@ -148,6 +151,7 @@ remind -m cabinet --config
   - With `--tags tag1,tag2`: only sends reminders that have at least one of the specified tags.
   - With `--tags __ALL__`: sends all reminders for today regardless of tags (failsafe; not recommended for regular use).
   - Use `--dry-run` to see what would be sent without actually sending anything.
+  - Also checks PyPI for a newer RemindMail release and emails once per version when `remindmail → update-checks` is enabled (default).
   - `remind -g --file=/path/to/special/remindmail.yml` will use the specified file instead of the default.
   - I recommend setting up a crontab.
 - `remind --later`: Emails reminders that are marked with `[later]`

--- a/setup.cfg
+++ b/setup.cfg
@@ -26,6 +26,7 @@ install_requires =
     prompt_toolkit>=3.0.0
     python-dateutil>=2.8.0
     PyYAML>=6.0.0
+    packaging>=21.0
 [options.packages.find]
 where=src
 

--- a/src/remind/reminder_manager.py
+++ b/src/remind/reminder_manager.py
@@ -17,6 +17,7 @@ from remind.yaml_manager import YAMLManager
 import yaml
 from cabinet import Cabinet, Mail
 from . import reminder, error_handler
+from .update_checker import UpdateChecker
 
 
 def complete_file_input(text: str, state: int) -> str:
@@ -177,6 +178,8 @@ class ReminderManager:
             FileNotFoundError: If the reminders file cannot be found.
             yaml.YAMLError: If there is an error parsing the YAML file.
         """
+        UpdateChecker(self.cabinet, self.mail).check_and_notify(is_dry_run=is_dry_run)
+
         # First parse without deletion to get all reminders
         self.parse_reminders_file(is_delete=False)
         self.cabinet.log(f"Parsed {len(self.parsed_reminders)} reminders", level="info")

--- a/src/remind/update_checker.py
+++ b/src/remind/update_checker.py
@@ -1,0 +1,193 @@
+"""
+Check PyPI for newer RemindMail releases and email the user once per version.
+"""
+
+from __future__ import annotations
+
+import json
+import urllib.error
+import urllib.request
+from importlib.metadata import PackageNotFoundError, version as package_version
+from typing import Any, Optional
+
+from packaging.version import InvalidVersion, Version
+
+PYPI_JSON_URL = "https://pypi.org/pypi/remindmail/json"
+PACKAGE_NAME = "remindmail"
+REQUEST_TIMEOUT_SECONDS = 10
+
+
+def _display_version(version_str: str) -> str:
+    """Return a human-friendly version without the PEP 440 epoch prefix."""
+    if "!" in version_str:
+        return version_str.split("!", 1)[1]
+    return version_str
+
+
+def _parse_version(version_str: str) -> Optional[Version]:
+    try:
+        return Version(version_str)
+    except InvalidVersion:
+        return None
+
+
+def _truthy(value: Any) -> bool:
+    """Treat missing/None as enabled; accept common falsey config strings."""
+    if value is None:
+        return True
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, (int, float)):
+        return value != 0
+    if isinstance(value, str):
+        return value.strip().lower() not in {"", "0", "false", "no", "off"}
+    return bool(value)
+
+
+def fetch_latest_pypi_version(
+    url: str = PYPI_JSON_URL, timeout: int = REQUEST_TIMEOUT_SECONDS
+) -> Optional[str]:
+    """
+    Fetch the latest RemindMail version string from the PyPI JSON API.
+
+    Returns:
+        The version string (e.g. ``1!3.5.0``), or None on network/parse failure.
+    """
+    try:
+        with urllib.request.urlopen(url, timeout=timeout) as response:
+            payload = json.load(response)
+    except (urllib.error.URLError, TimeoutError, json.JSONDecodeError, ValueError):
+        return None
+
+    version_str = (payload.get("info") or {}).get("version")
+    if not version_str or not isinstance(version_str, str):
+        return None
+    return version_str
+
+
+def get_installed_version() -> Optional[str]:
+    """Return the installed remindmail version, or None if unavailable."""
+    try:
+        return package_version(PACKAGE_NAME)
+    except PackageNotFoundError:
+        return None
+
+
+def should_notify(
+    installed: str,
+    latest: str,
+    last_notified: Optional[str],
+) -> bool:
+    """
+    Return True when latest is newer than installed and has not been emailed yet.
+    """
+    installed_v = _parse_version(installed)
+    latest_v = _parse_version(latest)
+    if installed_v is None or latest_v is None:
+        return False
+    if latest_v <= installed_v:
+        return False
+    if last_notified:
+        last_v = _parse_version(last_notified)
+        if last_v is not None and latest_v <= last_v:
+            return False
+    return True
+
+
+def build_update_email(latest: str, installed: str) -> tuple[str, str]:
+    """Return (subject, body) for a release notification email."""
+    latest_display = _display_version(latest)
+    installed_display = _display_version(installed)
+    subject = f"🎉 RemindMail {latest_display} Released"
+    body = (
+        f"A new version of RemindMail is available.<br><br>"
+        f"<b>Installed:</b> {installed_display}<br>"
+        f"<b>Latest:</b> {latest_display}<br><br>"
+        f"Upgrade with:<br>"
+        f"<code>pip install -U remindmail</code><br><br>"
+        f"Release notes: "
+        f'<a href="https://github.com/tylerjwoodfin/remindmail/releases">'
+        f"https://github.com/tylerjwoodfin/remindmail/releases</a>"
+    )
+    return subject, body
+
+
+class UpdateChecker:
+    """
+    Optionally emails the user when a newer RemindMail version is on PyPI.
+
+    Controlled by Cabinet ``remindmail → update-checks`` (default True).
+    Stores ``remindmail → last_notified_version`` so each release is emailed once.
+    """
+
+    def __init__(self, cabinet: Any, mail: Any) -> None:
+        self.cabinet = cabinet
+        self.mail = mail
+
+    def check_and_notify(self, is_dry_run: bool = False) -> bool:
+        """
+        Check PyPI and send an update email when appropriate.
+
+        Args:
+            is_dry_run: If True, log what would be sent without emailing or
+                updating Cabinet.
+
+        Returns:
+            True if an update email was sent (or would be sent on dry-run).
+        """
+        enabled = self.cabinet.get("remindmail", "update-checks")
+        if not _truthy(enabled):
+            self.cabinet.log("Update checks disabled; skipping", level="debug")
+            return False
+
+        installed = get_installed_version()
+        if not installed:
+            self.cabinet.log(
+                "Could not determine installed RemindMail version; skipping update check",
+                level="debug",
+            )
+            return False
+
+        latest = fetch_latest_pypi_version()
+        if not latest:
+            self.cabinet.log(
+                "Could not fetch latest RemindMail version from PyPI; skipping update check",
+                level="debug",
+            )
+            return False
+
+        last_notified = self.cabinet.get("remindmail", "last_notified_version")
+        if isinstance(last_notified, str):
+            last_notified_str: Optional[str] = last_notified
+        else:
+            last_notified_str = None
+
+        if not should_notify(installed, latest, last_notified_str):
+            self.cabinet.log(
+                f"No update email needed (installed={installed}, latest={latest}, "
+                f"last_notified={last_notified_str})",
+                level="debug",
+            )
+            return False
+
+        subject, body = build_update_email(latest, installed)
+        if is_dry_run:
+            self.cabinet.log(
+                f"[dry-run] Would send update email: {subject}", level="info"
+            )
+            return True
+
+        try:
+            self.mail.send(subject, body)
+            self.cabinet.put("remindmail", "last_notified_version", value=latest)
+            self.cabinet.log(
+                f"Sent update email for RemindMail {_display_version(latest)}",
+                level="info",
+            )
+            return True
+        except Exception as exc:  # noqa: BLE001 — never fail generate on update email
+            self.cabinet.log(
+                f"Failed to send update email: {exc}",
+                level="error",
+            )
+            return False

--- a/test/test_update_checker.py
+++ b/test/test_update_checker.py
@@ -1,0 +1,120 @@
+"""Tests for RemindMail update-check emails (TJW-318)."""
+
+import json
+import unittest
+from unittest.mock import MagicMock, patch
+
+from remind.update_checker import (
+    UpdateChecker,
+    build_update_email,
+    should_notify,
+    _truthy,
+)
+
+
+class TruthyTests(unittest.TestCase):
+    def test_none_defaults_true(self):
+        self.assertTrue(_truthy(None))
+
+    def test_false_values(self):
+        for value in (False, 0, "false", "False", "no", "off", ""):
+            self.assertFalse(_truthy(value), msg=repr(value))
+
+    def test_true_values(self):
+        for value in (True, 1, "true", "yes"):
+            self.assertTrue(_truthy(value), msg=repr(value))
+
+
+class ShouldNotifyTests(unittest.TestCase):
+    def test_newer_version_notifies(self):
+        self.assertTrue(should_notify("1!3.4.1", "1!4.0.0", None))
+
+    def test_same_version_skips(self):
+        self.assertFalse(should_notify("1!4.0.0", "1!4.0.0", None))
+
+    def test_older_latest_skips(self):
+        self.assertFalse(should_notify("1!4.0.0", "1!3.4.0", None))
+
+    def test_already_notified_skips(self):
+        self.assertFalse(should_notify("1!3.4.1", "1!4.0.0", "1!4.0.0"))
+
+    def test_newer_than_last_notified_sends(self):
+        self.assertTrue(should_notify("1!3.4.1", "1!4.1.0", "1!4.0.0"))
+
+    def test_invalid_versions_skip(self):
+        self.assertFalse(should_notify("not-a-version", "1!4.0.0", None))
+
+
+class BuildUpdateEmailTests(unittest.TestCase):
+    def test_subject_strips_epoch(self):
+        subject, body = build_update_email("1!4.0.0", "1!3.4.1")
+        self.assertEqual(subject, "🎉 RemindMail 4.0.0 Released")
+        self.assertIn("pip install -U remindmail", body)
+        self.assertIn("3.4.1", body)
+        self.assertIn("4.0.0", body)
+
+
+class UpdateCheckerTests(unittest.TestCase):
+    def setUp(self):
+        self.cabinet = MagicMock()
+        self.mail = MagicMock()
+        self.store = {}
+
+        def fake_get(*keys, **kwargs):
+            path = ".".join(str(k) for k in keys)
+            return self.store.get(path)
+
+        def fake_put(*keys, value=None, **kwargs):
+            path = ".".join(str(k) for k in keys)
+            self.store[path] = value
+
+        self.cabinet.get.side_effect = fake_get
+        self.cabinet.put.side_effect = fake_put
+        self.cabinet.log = MagicMock()
+        self.checker = UpdateChecker(self.cabinet, self.mail)
+
+    @patch("remind.update_checker.fetch_latest_pypi_version", return_value="1!4.0.0")
+    @patch("remind.update_checker.get_installed_version", return_value="1!3.4.1")
+    def test_sends_once_and_records_version(self, _installed, _latest):
+        self.assertTrue(self.checker.check_and_notify())
+        self.mail.send.assert_called_once()
+        subject = self.mail.send.call_args[0][0]
+        self.assertEqual(subject, "🎉 RemindMail 4.0.0 Released")
+        self.assertEqual(self.store["remindmail.last_notified_version"], "1!4.0.0")
+
+        self.mail.send.reset_mock()
+        self.assertFalse(self.checker.check_and_notify())
+        self.mail.send.assert_not_called()
+
+    @patch("remind.update_checker.fetch_latest_pypi_version", return_value="1!4.0.0")
+    @patch("remind.update_checker.get_installed_version", return_value="1!3.4.1")
+    def test_disabled_via_cabinet(self, _installed, _latest):
+        self.store["remindmail.update-checks"] = False
+        self.assertFalse(self.checker.check_and_notify())
+        self.mail.send.assert_not_called()
+
+    @patch("remind.update_checker.fetch_latest_pypi_version", return_value="1!4.0.0")
+    @patch("remind.update_checker.get_installed_version", return_value="1!3.4.1")
+    def test_dry_run_does_not_send_or_record(self, _installed, _latest):
+        self.assertTrue(self.checker.check_and_notify(is_dry_run=True))
+        self.mail.send.assert_not_called()
+        self.assertNotIn("remindmail.last_notified_version", self.store)
+
+    @patch("remind.update_checker.urllib.request.urlopen")
+    def test_fetch_latest_parses_pypi_json(self, mock_urlopen):
+        payload = json.dumps({"info": {"version": "1!4.0.0"}}).encode()
+        mock_cm = MagicMock()
+        mock_cm.__enter__.return_value.read.return_value = payload
+        # json.load reads via the file-like object
+        from io import BytesIO
+
+        mock_cm.__enter__.return_value = BytesIO(payload)
+        mock_urlopen.return_value = mock_cm
+
+        from remind.update_checker import fetch_latest_pypi_version
+
+        self.assertEqual(fetch_latest_pypi_version(), "1!4.0.0")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- During `remind --generate`, check PyPI for a newer RemindMail version and email the user once per release (`🎉 RemindMail X.Y.Z Released`) with upgrade instructions.
- Configurable via Cabinet `remindmail → update-checks` (default `true`); records `last_notified_version` so each version is only emailed once.
- README and unit tests updated; adds `packaging` dependency for PEP 440 version comparison.

## Test plan
- [ ] `PYTHONPATH=src python3 -m unittest discover -s test -p 'test_*.py'`
- [ ] With `update-checks` unset/true and a mocked newer PyPI version, `--generate` sends one update email and stores `last_notified_version`
- [ ] Running `--generate` again does not re-send for the same version
- [ ] Setting `remindmail.update-checks` to `false` skips the check
- [ ] `--dry-run` logs the would-be email without sending or writing Cabinet
